### PR TITLE
fixed your published build

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,11 +2,11 @@
   "name": "sabr",
   "version": "0.1.7",
   "description": "Klasa Discord API Library Framework",
-  "main": "dist/index",
-  "typings": "dist/index",
+  "main": "dist/index.js",
+  "typings": "dist/index.d.ts",
   "scripts": {
     "build": "tsc -p .",
-    "prepack": "tsc --declaration",
+    "prepack": "npm run build",
     "patch": "npm version patch && npm publish",
     "minor": "npm version minor && npm publish"
   },
@@ -32,6 +32,7 @@
     "typescript": "^3.9.5"
   },
   "files": [
-    "dist/*"
+    "dist/",
+    "!dist/tsconfig.tsbuildinfo"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "declarationMap": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "incremental": true,


### PR DESCRIPTION
This should fix it

The primary thing was the `.js` and `.d.ts` extensions on `main` and `types`.

the `tsc --declarations` is pointless since you're already emitting declarations in your tsconfig. To your tsconfig I added `declarationMap` which are sourcemaps for declaration files, everybody loves fantastic debugging capabilities and good stacktraces right ;) 

And lastly the exclusion of `tsconfig.tsbuildinfo` in files is the file that is emitted by tsc for incremental builds, but we don't want that in the tarball.

Final tarball:
```sh
❯ npm publish --dry-run

> sabr@0.1.7 prepack .
> npm run build       


> sabr@0.1.7 build C:\Users\favna\Downloads\sabr-master
> tsc -p .

npm notice 
npm notice package: sabr@0.1.7
npm notice === Tarball Contents === 
npm notice 1.1kB  LICENSE
npm notice 11.0kB dist/structures/BotClient.js      
npm notice 1.0kB  dist/structures/Command.js        
npm notice 727B   dist/index.js
npm notice 862B   package.json
npm notice 1.1kB  dist/structures/BotClient.d.ts.map
npm notice 9.1kB  dist/structures/BotClient.js.map  
npm notice 1.1kB  dist/structures/Command.d.ts.map  
npm notice 779B   dist/structures/Command.js.map    
npm notice 144B   dist/index.d.ts.map
npm notice 134B   dist/index.js.map
npm notice 46B    README.md
npm notice 1.4kB  dist/structures/BotClient.d.ts    
npm notice 1.5kB  dist/structures/Command.d.ts      
npm notice 115B   dist/index.d.ts
npm notice === Tarball Details === 
npm notice name:          sabr
npm notice version:       0.1.7
npm notice package size:  7.3 kB
npm notice unpacked size: 30.1 kB
npm notice shasum:        e26f1539591195af1044f05af80b7eb4f11d5616
npm notice integrity:     sha512-4PCqGFOFo5XtK[...]R6q9kOgFDTDwg==
npm notice total files:   15
npm notice 
+ sabr@0.1.7
```